### PR TITLE
Fix issue that .systemOrange is nearly invisible in darkmode

### DIFF
--- a/src/Support/AppDelegate.swift
+++ b/src/Support/AppDelegate.swift
@@ -42,21 +42,13 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     // Create red notification badge view
     // https://github.com/DeveloperMaris/ToolReleases/blob/master/ToolReleases/PopoverController.swift
     lazy var redBadge: NSView = {
-        let view = StatusItemBadgeView(frame: NSRect(x: 0, y: 0, width: 0, height: 0), color: .systemRed)
-        view.translatesAutoresizingMaskIntoConstraints = false
-        view.wantsLayer = true
-        view.layer?.masksToBounds = true
-        return view
+        StatusItemBadgeView(frame: .zero, color: .systemRed)
     }()
     
     // Create orange notification badge view
     // https://github.com/DeveloperMaris/ToolReleases/blob/master/ToolReleases/PopoverController.swift
     lazy var orangeBadge: NSView = {
-        let view = StatusItemBadgeView(frame: NSRect(x: 0, y: 0, width: 0, height: 0), color: .systemOrange)
-        view.translatesAutoresizingMaskIntoConstraints = false
-        view.wantsLayer = true
-        view.layer?.masksToBounds = true
-        return view
+        StatusItemBadgeView(frame: .zero, color: .orange)
     }()
     
     func applicationDidFinishLaunching(_ aNotification: Notification) {

--- a/src/Support/AppDelegate.swift
+++ b/src/Support/AppDelegate.swift
@@ -48,7 +48,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     // Create orange notification badge view
     // https://github.com/DeveloperMaris/ToolReleases/blob/master/ToolReleases/PopoverController.swift
     lazy var orangeBadge: NSView = {
-        StatusItemBadgeView(frame: .zero, color: .orange)
+        StatusItemBadgeView(frame: .zero, color: .systemOrange)
     }()
     
     func applicationDidFinishLaunching(_ aNotification: Notification) {

--- a/src/Support/Views/StatusItemBadgeView.swift
+++ b/src/Support/Views/StatusItemBadgeView.swift
@@ -17,6 +17,8 @@ class StatusItemBadgeView: NSView {
     init(frame frameRect: NSRect, color : NSColor) {
         self.color = color
         super.init(frame: frameRect)
+        translatesAutoresizingMaskIntoConstraints = false
+        wantsLayer = true
     }
     
     required init?(coder: NSCoder) {
@@ -30,5 +32,14 @@ class StatusItemBadgeView: NSView {
         fillColor.set()
         path.fill()
     }
-    
+
+    override func layout() {
+        super.layout()
+        layer?.masksToBounds = true
+        layer?.backgroundColor = color.cgColor
+
+        layer?.borderColor = NSColor.windowBackgroundColor.cgColor
+        layer?.borderWidth = 0.5
+        layer?.cornerRadius = frame.size.height / 2.0
+    }
 }


### PR DESCRIPTION
We noticed that the badge is nearly invisible in dark mode on top of our our icon. Actually .systemOrange is slightly lighter than .orange.

Additionally I suggest a small border to improve the contrast and usability even further.
Original:
![Bildschirmfoto 2022-11-14 um 08 55 15](https://user-images.githubusercontent.com/86787599/201612929-070a5fd5-0e89-448d-9986-c17e24358105.png)
Improvement:
![Bildschirmfoto 2022-11-14 um 09 34 32](https://user-images.githubusercontent.com/86787599/201612982-5c70f565-66b6-47c8-8f1b-6f5417d9122f.png)
Colors to compare:
![Bildschirmfoto 2022-11-14 um 08 52 16](https://user-images.githubusercontent.com/86787599/201612888-454edf04-db22-46b6-a411-591b31be779c.png)