### PR TITLE
Update DisablePrivilegedHelperTool language in Jamf Pro Custom Schema

### DIFF
--- a/Jamf Pro Custom Schema/Jamf Pro Custom Schema.json
+++ b/Jamf Pro Custom Schema/Jamf Pro Custom Schema.json
@@ -1011,11 +1011,11 @@
       ]
 		},
     "DisablePrivilegedHelperTool": {
-      "title": "Disable Privileged Helper Tool",
-      "description": "Option to disable the Privileged Helper Tool. Re-enabling requires the reinstallation of the Support App.",
+      "title": "Enable or Disable Privileged Helper Tool",
+      "description": "Option to enable or disable the Privileged Helper Tool. Re-enabling requires the reinstallation of the Support App.",
       "type": "boolean",
       "options": {
-        "enum_titles": ["Enable", "Disable"],
+        "enum_titles": ["Disable", "Enable"],
         "infoText": "Key name: DisablePrivilegedHelperTool"
       },
       "links": [


### PR DESCRIPTION
Because a boolean TRUE for this key disables the helper tool, the title, description, and order of values for Disable and Enable have been changed to reflect what this key actually does. Previously, selecting "Enable" disabled the helper tool, and vice versa.