### PR TITLE
Update Support App Configuration Sample.mobileconfig

### DIFF
--- a/Configuration Profile Samples/Support App Configuration Sample.mobileconfig
+++ b/Configuration Profile Samples/Support App Configuration Sample.mobileconfig
@@ -5,90 +5,76 @@
 	<key>PayloadContent</key>
 	<array>
 		<dict>
-			<key>PayloadContent</key>
-			<dict>
-				<key>nl.root3.support</key>
-				<dict>
-					<key>Forced</key>
-					<array>
-						<dict>
-							<key>mcx_preference_settings</key>
-							<dict>
-								<key>ExtensionLinkA</key>
-								<string>defaults write /Library/Preferences/nl.root3.support.plist ExtensionLoadingA -bool true; /usr/local/bin/jamf policy; /usr/local/bin/jamf_last_check-in_time.zsh</string>
-								<key>ExtensionSymbolA</key>
-								<string>clock.badge.checkmark.fill</string>
-								<key>ExtensionTitleA</key>
-								<string>Last MDM Check-In</string>
-								<key>ExtensionTypeA</key>
-								<string>DistributedNotification</string>
-								<key>FirstRowLinkLeft</key>
-								<string>com.teamviewer.TeamViewer</string>
-								<key>FirstRowLinkMiddle</key>
-								<string>https://support.root3.nl</string>
-								<key>FirstRowLinkRight</key>
-								<string>com.jamfsoftware.selfservice.mac</string>
-								<key>FirstRowSubtitleLeft</key>
-								<string>Share your screen</string>
-								<key>FirstRowSubtitleMiddle</key>
-								<string>Now</string>
-								<key>FirstRowSubtitleRight</key>
-								<string>Download Apps</string>
-								<key>FirstRowSymbolLeft</key>
-								<string>cursorarrow.and.square.on.square.dashed</string>
-								<key>FirstRowSymbolMiddle</key>
-								<string>lifepreserver</string>
-								<key>FirstRowSymbolRight</key>
-								<string>cart.badge.plus</string>
-								<key>FirstRowTitleLeft</key>
-								<string>Remote Support</string>
-								<key>FirstRowTitleMiddle</key>
-								<string>Get Support</string>
-								<key>FirstRowTitleRight</key>
-								<string>Self Service</string>
-								<key>FirstRowTypeLeft</key>
-								<string>App</string>
-								<key>FirstRowTypeMiddle</key>
-								<string>URL</string>
-								<key>FirstRowTypeRight</key>
-								<string>App</string>
-								<key>FooterText</key>
-								<string>Provided by your **IT department** with ❤️</string>
-								<key>HideFirstRow</key>
-								<false/>
-								<key>HideSecondRow</key>
-								<true/>
-								<key>InfoItemFive</key>
-								<string>Password</string>
-								<key>InfoItemSix</key>
-								<string>ExtensionA</string>
-								<key>Logo</key>
-								<string>/Library/Application Support/JAMF/swift-64x64_2x.png</string>
-								<key>NotificationIcon</key>
-								<string>/Library/Application Support/JAMF/swift-64x64_2x.png</string>
-								<key>OnAppearAction</key>
-								<string>/usr/local/bin/jamf_last_check-in_time.zsh</string>
-								<key>PasswordExpiryLimit</key>
-								<integer>14</integer>
-								<key>PasswordLabel</key>
-								<string>Cloud Password</string>
-								<key>PasswordType</key>
-								<string>KerberosSSO</string>
-								<key>ShowWelcomeScreen</key>
-								<true/>
-								<key>StatusBarIconNotifierEnabled</key>
-								<true/>
-								<key>StorageLimit</key>
-								<integer>90</integer>
-								<key>Title</key>
-								<string>Hello **Support App** 2.4</string>
-								<key>UptimeDaysLimit</key>
-								<integer>21</integer>
-							</dict>
-						</dict>
-					</array>
-				</dict>
-			</dict>
+			<key>ExtensionLinkA</key>
+			<string>defaults write /Library/Preferences/nl.root3.support.plist ExtensionLoadingA -bool true; /usr/local/bin/jamf policy; /usr/local/bin/jamf_last_check-in_time.zsh</string>
+			<key>ExtensionSymbolA</key>
+			<string>clock.badge.checkmark.fill</string>
+			<key>ExtensionTitleA</key>
+			<string>Last MDM Check-In</string>
+			<key>ExtensionTypeA</key>
+			<string>DistributedNotification</string>
+			<key>FirstRowLinkLeft</key>
+			<string>com.teamviewer.TeamViewer</string>
+			<key>FirstRowLinkMiddle</key>
+			<string>https://support.root3.nl</string>
+			<key>FirstRowLinkRight</key>
+			<string>com.jamfsoftware.selfservice.mac</string>
+			<key>FirstRowSubtitleLeft</key>
+			<string>Share your screen</string>
+			<key>FirstRowSubtitleMiddle</key>
+			<string>Now</string>
+			<key>FirstRowSubtitleRight</key>
+			<string>Download Apps</string>
+			<key>FirstRowSymbolLeft</key>
+			<string>cursorarrow.and.square.on.square.dashed</string>
+			<key>FirstRowSymbolMiddle</key>
+			<string>lifepreserver</string>
+			<key>FirstRowSymbolRight</key>
+			<string>cart.badge.plus</string>
+			<key>FirstRowTitleLeft</key>
+			<string>Remote Support</string>
+			<key>FirstRowTitleMiddle</key>
+			<string>Get Support</string>
+			<key>FirstRowTitleRight</key>
+			<string>Self Service</string>
+			<key>FirstRowTypeLeft</key>
+			<string>App</string>
+			<key>FirstRowTypeMiddle</key>
+			<string>URL</string>
+			<key>FirstRowTypeRight</key>
+			<string>App</string>
+			<key>FooterText</key>
+			<string>Provided by your **IT department** with ❤️</string>
+			<key>HideFirstRow</key>
+			<false/>
+			<key>HideSecondRow</key>
+			<true/>
+			<key>InfoItemFive</key>
+			<string>Password</string>
+			<key>InfoItemSix</key>
+			<string>ExtensionA</string>
+			<key>Logo</key>
+			<string>/Library/Application Support/JAMF/swift-64x64_2x.png</string>
+			<key>NotificationIcon</key>
+			<string>/Library/Application Support/JAMF/swift-64x64_2x.png</string>
+			<key>OnAppearAction</key>
+			<string>/usr/local/bin/jamf_last_check-in_time.zsh</string>
+			<key>PasswordExpiryLimit</key>
+			<integer>14</integer>
+			<key>PasswordLabel</key>
+			<string>Cloud Password</string>
+			<key>PasswordType</key>
+			<string>KerberosSSO</string>
+			<key>ShowWelcomeScreen</key>
+			<true/>
+			<key>StatusBarIconNotifierEnabled</key>
+			<true/>
+			<key>StorageLimit</key>
+			<integer>90</integer>
+			<key>Title</key>
+			<string>Hello **Support App** 2.4</string>
+			<key>UptimeDaysLimit</key>
+			<integer>21</integer>
 			<key>PayloadDescription</key>
 			<string></string>
 			<key>PayloadDisplayName</key>
@@ -96,11 +82,11 @@
 			<key>PayloadEnabled</key>
 			<true/>
 			<key>PayloadIdentifier</key>
-			<string>com.apple.ManagedClient.preferences.E07B484A-FC4A-450B-A0E9-3BC0B737974B</string>
+			<string>nl.root3.support.E07B484A-FC4A-450B-A0E9-3BC0B737974B</string>
 			<key>PayloadOrganization</key>
 			<string>Root3</string>
 			<key>PayloadType</key>
-			<string>com.apple.ManagedClient.preferences</string>
+			<string>nl.root3.support</string>
 			<key>PayloadUUID</key>
 			<string>E07B484A-FC4A-450B-A0E9-3BC0B737974B</string>
 			<key>PayloadVersion</key>


### PR DESCRIPTION
This converts the example profile from the legacy MCX type and instead sets the `PayloadType` directly.