### PR TITLE
Update postinstall

### DIFF
--- a/pkgbuild/scripts/postinstall
+++ b/pkgbuild/scripts/postinstall
@@ -60,6 +60,7 @@ if is-at-least 13.0 ${os_version}; then
 		uid=$(id -u "${username}")
 
 		launchctl asuser "${uid}" sudo -u "${username}" open -na "${install_location}"
+		sleep 5 # need to let it build the app sandbox to avoid permissions pop ups
 	fi
 fi
 


### PR DESCRIPTION
https://github.com/root3nl/SupportApp/issues/244

Currently it's loaded and then immediately killed in the postinstall, not giving it enough time to build the app sandbox. This can result in "Support differs from previously opened versions" pop up errors in the GUI.