### PR TITLE
Updated SAP Privileges extension scripts for SupportApp 3.0

### DIFF
--- a/Extension Sample Scripts/SAP Privileges/sap_privileges_change_permissions.zsh
+++ b/Extension Sample Scripts/SAP Privileges/sap_privileges_change_permissions.zsh
@@ -1,0 +1,53 @@
+#!/bin/zsh --no-rcs
+
+# Support App Extension - SAP Privileges Change Permissions
+#
+#
+# Copyright 2022 Root3 B.V. All rights reserved.
+#
+# Support App Extension to change user permissions with SAP Privileges.
+#
+# REQUIREMENTS:
+# - Jamf Pro Binary
+# - SAP Privileges: https://github.com/SAP/macOS-enterprise-privileges
+#
+# THE SOFTWARE IS PROVIDED BY ROOT3 B.V. "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO
+# EVENT SHALL ROOT3 B.V. BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+# WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+# IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+# ---------------------    do not edit below this line    ----------------------
+
+# Support App preference plist
+preference_file_location="/Library/Preferences/nl.root3.support.plist"
+
+# Set Extension ID
+extension_id="privileges"
+
+# SAP Privileges CLI
+sap_privileges_cli="/Applications/Privileges.app/Contents/macOS/PrivilegesCLI"
+
+# Start spinning indicator
+defaults write "${preference_file_location}" "${extension_id}_loading" -bool true
+
+# Replace value with placeholder while loading
+defaults write "${preference_file_location}" "${extension_id}" -string "KeyPlaceholder"
+
+# Get the username and uid of the currently logged in user
+username=$(scutil <<< "show State:/Users/ConsoleUser" | awk '/Name :/ && ! /loginwindow/ { print $3 }')
+uid=$(id -u "$username")
+
+# Check if user is administrator
+is_admin=$(dsmemberutil checkmembership -U "${username}" -G admin)
+
+# Change permissions
+if [[ ${is_admin} != *not* ]]; then
+  launchctl asuser "$uid" sudo -u ${username} ${sap_privileges_cli} --remove
+else
+  launchctl asuser "$uid" sudo -u ${username} ${sap_privileges_cli} --add
+fi
+
+# Run Support App Extension to report new permission status
+"/usr/local/bin/user_permissions.zsh"

--- a/Extension Sample Scripts/SAP Privileges/user_permissions.zsh
+++ b/Extension Sample Scripts/SAP Privileges/user_permissions.zsh
@@ -1,0 +1,51 @@
+#!/bin/zsh --no-rcs
+
+# Support App Extension - User Permissions
+#
+#
+# Copyright 2022 Root3 B.V. All rights reserved.
+#
+# Support App Extension to get the current user permission schema.
+#
+# REQUIREMENTS:
+# - Jamf Pro Binary
+#
+# THE SOFTWARE IS PROVIDED BY ROOT3 B.V. "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO
+# EVENT SHALL ROOT3 B.V. BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+# WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+# IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+# ---------------------    do not edit below this line    ----------------------
+
+# Support App preference plist
+preference_file_location="/Library/Preferences/nl.root3.support.plist"
+
+# Set Extension ID
+extension_id="privileges"
+
+# Start spinning indicator
+defaults write "${preference_file_location}" "${extension_id}_loading" -bool true
+
+# Replace value with placeholder while loading
+defaults write "${preference_file_location}" "${extension_id}" -string "KeyPlaceholder"
+
+# Keep loading effect active for 0.5 seconds
+sleep 0.5
+
+# Get the username of the currently logged in user
+username=$(scutil <<< "show State:/Users/ConsoleUser" | awk '/Name :/ && ! /loginwindow/ { print $3 }')
+
+# Check if user is administrator
+is_admin=$(dsmemberutil checkmembership -U "${username}" -G admin)
+
+# Change permissions
+if [[ ${is_admin} != *not* ]]; then
+  defaults write "${preference_file_location}" "${extension_id}" -string "Administrator"
+else
+  defaults write "${preference_file_location}" "${extension_id}" -string "Standard User"
+fi
+
+# Stop spinning indicator
+defaults write "${preference_file_location}" "${extension_id}_loading" -bool false


### PR DESCRIPTION
Updated SAP Privileges extension scripts to support new config structure for SupportApp 3.0. 

**Be sure to use `privileges` as the Extension ID in your configuration profile!**

<img width="373" height="794" alt="Screenshot 2025-11-14 at 9 59 18 AM" src="https://github.com/user-attachments/assets/294d6137-3f44-468d-ab9c-7501e6b5a9d9" />
